### PR TITLE
Fixes test file

### DIFF
--- a/lispytest/test.ls2
+++ b/lispytest/test.ls2
@@ -28,9 +28,9 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Simple Macro Declaration
-; (macro print ()
-; 	(console.log ~...rest))
-; (print "Lets" "print" "a" a)
+(macro print (...rest)
+	(console.log ~...rest))
+ (print "Lets" "print" "a" a)
 ;; Output: console.log("Lets", "print", "a", a);
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;


### PR DESCRIPTION
During macro declaration you need to explicitly specify the '...rest' parameter to be able to dereference it.
